### PR TITLE
chore: replace generic emails with GitHub references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ Releases are automated via GitHub Actions:
 
 - **Issues**: [GitHub Issues](https://github.com/netresearch/phpbu-docker/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/netresearch/phpbu-docker/discussions)
-- **Security**: security@netresearch.de
+- **Security**: [GitHub Security Advisories](https://github.com/netresearch/phpbu-docker/security/advisories/new)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Replace generic `@netresearch.de` email addresses with GitHub-native references
- Add `support` section to package metadata with Issues/Source URLs
- Use GitHub Security Advisories for vulnerability reporting
- Use GitHub Issues for general support/contact

## Motivation

Generic email addresses in public repositories attract spam and create maintenance overhead. GitHub provides better mechanisms for each use case:
- **Security**: Private vulnerability reporting via Security Advisories
- **Support**: Issue tracker with templates and labels
- **Contact**: Discussions for general questions

## Test plan

- [ ] Verify package metadata is valid (composer validate)
- [ ] Verify links in documentation point to correct URLs
- [ ] Verify no functional email addresses were removed (only metadata/docs)
