### PR TITLE
ci: migrate to netresearch/.github reusable container workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,26 +16,18 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
-        with:
-          dockerfile: Dockerfile
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Validate bake file
-        run: docker buildx bake --print
-
   build:
-    needs: [lint]
+    # Dockerfile lint (hadolint) and bake-graph validation moved to
+    # .github/workflows/lint.yml — the hadolint piece now delegates to
+    # netresearch/.github's reusable lint-container.yml. The bake-graph
+    # check stays inline there because the reusable model is single-target
+    # docker/build-push-action, not bake. This `build` job likewise stays
+    # inline: the bake multi-target shape (minimal + full variants from
+    # docker-bake.hcl with shared cache and combined tag fan-out) doesn't
+    # map onto build-container.yml's single-target shape, and a
+    # bake-to-matrix refactor would either duplicate the tag fan-out into
+    # `metadata-tags` for two parallel reusable calls or abandon
+    # docker-bake.hcl entirely. Both invasive; flagged as upstream follow-up.
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Netresearch DTT GmbH
+#
+# Static checks for the phpbu-docker repo.
+#
+# Splits into:
+#   - container-lint → delegates Dockerfile (hadolint) to netresearch/.github's
+#                      reusable lint-container.yml on @main. Reusable pins
+#                      hadolint to v2.14.0, which handles Docker 25's
+#                      HEALTHCHECK --start-interval correctly. No
+#                      shell-scandirs because phpbu-docker does not ship its
+#                      own shell helpers (docker-entrypoint.sh is the only
+#                      shipped script and lives under the build context, not
+#                      a separate scandir).
+#   - bake-validate  → stays inline. Validates the docker-bake.hcl multi-
+#                      target build graph via `docker buildx bake --print`.
+#                      Caller-specific — the reusable model is single-target
+#                      build-push-action, not bake.
+
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  container-lint:
+    # hadolint only — no shellcheck (shell-scandirs left empty).
+    uses: netresearch/.github/.github/workflows/lint-container.yml@main
+    permissions:
+      contents: read
+
+  bake-validate:
+    name: docker buildx bake --print
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Validate bake file
+        run: docker buildx bake --print

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,36 +1,38 @@
-name: OpenSSF Scorecard
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Netresearch DTT GmbH
+#
+# OpenSSF Scorecard — supply-chain security health check.
+# Delegates to the org-wide reusable in netresearch/.github.
+# Runs weekly against main and uploads SARIF to GitHub code-scanning.
+# Results also surface on the OpenSSF Scorecard public dashboard
+# (https://securityscorecards.dev/) once enabled.
+
+name: scorecard
 
 on:
   branch_protection_rule:
   schedule:
-    - cron: '0 6 * * 1'  # Weekly on Monday
+    - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
   push:
     branches: [main]
+  workflow_dispatch:
 
-permissions: read-all
+# Top-level permissions explicitly enumerated (SonarCloud rule
+# githubactions:S8234). The reusable's job requests its own
+# additional permissions via its own permissions block; this minimum
+# lets supporting tooling read metadata without granting writes.
+permissions:
+  contents: read
 
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
     permissions:
+      # required by scorecard-action for publishing results
       security-events: write
+      # needed to publish results and get a badge
       id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload results
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
-        with:
-          sarif_file: results.sarif
+      contents: read
+      # needed for nested API calls (Branch-Protection, Webhooks checks)
+      actions: read
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,19 +52,16 @@ jobs:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-${{ matrix.name }}'
 
+  # Secret-scanning now delegates to netresearch/.github's reusable, which
+  # runs betterleaks (gitleaks fork, OSS, no license required) against the
+  # full git history, uploads SARIF to GitHub code-scanning, and bakes in
+  # the dependabot[bot]+merge_group skip semantics. The trivy job above
+  # stays inline because it builds locally via bake before scanning — the
+  # security-container.yml reusable is designed for already-published
+  # images (matrix over tags) and can't be wired in until the build job
+  # itself migrates off bake.
   gitleaks:
-    runs-on: ubuntu-latest
-    # Skip for dependabot PRs - org secrets not available to external PRs
-    if: github.actor != 'dependabot[bot]'
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+      security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,26 +106,22 @@ jobs:
           docker run --rm --entrypoint which phpbu:ci-full gpg
           docker run --rm --entrypoint which phpbu:ci-full ssh
 
+  # The previous `structure-test` job (inline bake + container-structure-test
+  # download + run) now delegates to netresearch/.github's reusable
+  # smoke-test-container.yml. The reusable builds via docker/build-push-action
+  # rather than bake — equivalent here because the bake `ci` target is just
+  # `target = "minimal"` with `platforms = ["linux/amd64"]` and a local
+  # `phpbu:ci` tag, which the reusable replicates verbatim via `target:` +
+  # `image-tag:`. The `smoke-test` matrix job above stays inline: it covers
+  # phpbu-specific surface (TZ env-var sanitisation, read-only fs, simulate
+  # mode with a fixture config) that's outside the reusable's structure-test
+  # scope.
   structure-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build test image
-        uses: docker/bake-action@a66e1c87e2eca0503c343edf1d208c716d54b8a8 # v7.1.0
-        with:
-          targets: ci
-          load: true
-
-      - name: Install container-structure-test
-        run: |
-          curl -LO https://github.com/GoogleContainerTools/container-structure-test/releases/download/v1.19.3/container-structure-test-linux-amd64
-          echo "fa0fa333bb6ba5c14065e7468d2904f5c82d021d7e1c763c9a45c5f2fbe9ff5f  container-structure-test-linux-amd64" | sha256sum -c -
-          chmod +x container-structure-test-linux-amd64
-          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
-
-      - name: Run structure tests
-        run: container-structure-test test --image phpbu:ci --config tests/container-structure-test.yaml
+    uses: netresearch/.github/.github/workflows/smoke-test-container.yml@main
+    permissions:
+      contents: read
+    with:
+      image-tag: phpbu:ci
+      target: minimal
+      cst-config-path: tests/container-structure-test.yaml
+      cache-scope: structure-test


### PR DESCRIPTION
## Summary

Phase 4 of the container-CI consolidation across Netresearch container repos. Delegates 4 of phpbu-docker's CI workflows to the reusables in netresearch/.github that snipe-it-docker-compose-stack has been battle-testing in Phases 1-3. The build job and the trivy CVE job stay inline behind a structural blocker (docker buildx bake multi-target shape — flagged below).

## What migrated

| Workflow | Job(s) migrated | Before (lines) | After (lines) | Notes |
|---|---|---:|---:|---|
| scorecard.yml | full file | 36 | 38 | Delegates to scorecard.yml@main. Slight bump from added doc comments. |
| build.yml | extracted lint job → new lint.yml | 193 | 185 | build job stays inline (bake multi-target). |
| (new) lint.yml | hadolint + bake-graph-validate | — | 54 | hadolint via lint-container.yml@main; bake-validate inline (single-stage docker buildx bake --print). |
| test.yml | structure-test job | 131 | 127 | Delegates to smoke-test-container.yml@main; smoke-test matrix (TZ injection, read-only fs, simulate-mode) stays inline. |
| security.yml | gitleaks job | 70 | 67 | Delegates to gitleaks.yml@main (betterleaks, no license needed); trivy stays inline (bake-built local scan). |

Net total bytes: +41 lines on disk but **9 fewer third-party-action SHA pins** to maintain (30 → 21) — the reusables own that supply-chain surface centrally.

## What stays inline, and why

- **build.yml::build** — uses docker buildx bake with two targets (minimal + full from docker-bake.hcl) plus a shared GHA cache and a combined cosign sign + SLSA attest + trivy scan over both variants in one job. Migration to build-container.yml@main would require either two parallel reusable matrix calls (duplicating the bake tag fan-out into metadata-tags) or abandoning docker-bake.hcl entirely. Per task rule 10 (no workarounds for structural blockers), flagging as an upstream follow-up rather than inventing a kludge.
- **release.yml** — same bake multi-target shape plus GitHub Release creation. Same blocker.
- **security.yml::trivy** — currently does local bake build then scans both variants. The security-container.yml reusable is for already-published images. Migratable only after build.yml moves off bake.
- **test.yml::smoke-test** matrix — phpbu-specific surface (TZ env-var sanitisation against injection, read-only filesystem, simulate-mode with fixture config, full-variant tool presence). Outside the reusable's structure-test scope.
- **auto-merge.yml** + **cleanup-packages.yml** — explicitly out of scope (Dependabot/Renovate auto-merge orchestration; ghcr retention).

## Upstream follow-ups (do NOT block this PR)

1. **build.yml + release.yml bake refactor** — decide whether to keep docker-bake.hcl (and accept that build-container.yml@main is not reachable) or refactor to a matrix of reusable calls. Needs design discussion; not within this PR's scope.
2. **SonarCloud `githubactions:S7637`** ("use SHA hash for actions") — the new caller stubs pin netresearch/.github to @main (hard constraint #3, mandated by the user, memory ref feedback_no_sha_pin_own_reusables). Same rule-deactivation already done at project-Quality-Profile level for snipe-it; phpbu-docker likely needs the same treatment if it's SC-scanned. Cosmetic — does not affect runtime.
3. **Renovate digest-pinning auto-merge.yml** — independent observation from the audit. Commit 309fca0 ("chore(deps): update netresearch/.github digest to 22155f1") pinned `netresearch/.github` by SHA digest in `.github/workflows/auto-merge.yml`, which violates the org no-SHA-pin-for-`netresearch/*` policy. Likely needs a `renovate.json` `packageRules` exclusion for `netresearch/.github`. Tracking separately — not part of this PR (rule: do not touch auto-merge.yml).

## Hard-constraint compliance checklist

- [x] All `netresearch/.github` reusable refs use `@main`, never `@<sha>` (verified: `grep -nE "netresearch/\.github" .github/workflows/*.yml`).
- [x] All third-party action refs in the new files SHA-pinned with version-tag comments.
- [x] SPDX headers on new files use "Netresearch DTT GmbH".
- [x] All 4 commits signed (`G` flag from `git log --format='%G?'`) and `Signed-off-by:` matches `git config user.email`.
- [x] Conventional-commit prefixes, no AI attribution.
- [x] No `secrets: inherit` anywhere in the migrated files.
- [x] All migrated/new files end with single newline (`tail -c 2 | xxd -p` → `*0a`, never `0a0a`).
- [x] Atomic commits per workflow file, explicit-path `git add`.
- [x] No workarounds for the bake structural blocker — surfaced for user decision.

## Test plan

- [ ] CI runs on the PR (build, lint, scorecard, test, security workflows triggered by `pull_request` event).
- [ ] hadolint via reusable handles the existing Dockerfile (was on hadolint-action@v3.3.0; reusable pins hadolint v2.14.0).
- [ ] container-structure-test via reusable produces equivalent output to the previous inline bake-then-CST flow against `phpbu:ci` (minimal stage).
- [ ] betterleaks via gitleaks.yml@main scans the full history (cf. memory feedback_gitleaks_full_history_scan — there's nothing in this repo's history that should trigger, but SARIF should upload cleanly).
- [ ] Scorecard SARIF appears in the Security tab after merge to main.