### PR TITLE
fix(renovate): exclude first-party netresearch/* + add PR Quality Gates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@22155f1bdaf6b0b19a6efb1c40e6778722c62cff # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     with:
       safe-updates-only: true
       merge-strategy: rebase

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Netresearch DTT GmbH
+#
+# PR Quality Gates — caller for the org-wide reusable workflow.
+# Provides:
+#   - PR size labeling (warn over 500 lines, alert over 1000)
+#   - Auto-approve for maintainer PRs (OWNER/MEMBER/COLLABORATOR), so the
+#     branch-protection "1 approval" gate doesn't block trivial maintainer
+#     work; Copilot review still runs separately via the Copilot ruleset.
+# Reusable: netresearch/.github/.github/workflows/pr-quality.yml
+
+name: PR Quality Gates
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  quality:
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    with:
+      auto-approve-maintainers: true
+    permissions:
+      contents: read
+      pull-requests: write

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,17 @@
       "pinDigests": true
     },
     {
+      "description": "First-party Netresearch reusable workflows: never digest-pin. Org policy is @main (or @vN once tagged releases exist). Distinct from third-party actions which DO get SHA-pinned per supply-chain convention. Without this rule, Renovate's earlier digest-pinning produced commit 309fca0 (auto-merge.yml@<sha>) which violates that policy.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackagePatterns": [
+        "^netresearch/"
+      ],
+      "pinDigests": false,
+      "enabled": false
+    },
+    {
       "description": "Security updates - high priority",
       "matchCategories": [
         "security"


### PR DESCRIPTION
## Summary

Two related fixes for org-policy compliance, bundled because both are about phpbu-docker conforming to Netresearch standards on its CI infrastructure:

### 1. Renovate digest-pin exclusion for first-party reusables

Renovate has been digest-pinning `uses: netresearch/.github/.github/workflows/*@main` refs in this repo for months — four commits in the recent log do this (9fa7178, 4f38a92, aeb49e5, 309fca0). Each violates org policy: first-party Netresearch reusable workflows are called with `@main` (never SHA-pinned). Third-party actions (`actions/checkout`, `docker/build-push-action`, etc.) DO get SHA-pinned per supply-chain policy — different trust models.

- **`.github/workflows/auto-merge.yml`** — reverted the digest-pinned `auto-merge-deps.yml@22155f1...` back to `@main`. Same reusable, same behavior.
- **`renovate.json`** — added a packageRule that disables Renovate for github-actions deps matching `^netresearch/`. `enabled: false` means no PRs, no digest pins, no drift. The wide "Group GitHub Actions" rule still SHA-pins third-party actions exactly as before.

### 2. Add canonical PR Quality Gates caller

This repo was missing the standard `pr-quality.yml` caller that other Netresearch org repos use (netresearch/ofelia, ldap-selfservice-password-changer, the t3x-* TYPO3 extensions). The org reusable provides:

- PR size labeling (warns over 500 lines, alerts over 1000)
- Auto-approve for maintainer PRs whose `author_association` is OWNER/MEMBER/COLLABORATOR — satisfies the "1 approval" branch protection gate for routine maintainer work without bypassing the Copilot review (which runs separately via the Copilot ruleset)

Caller config matches netresearch/ofelia verbatim.

## Test plan

- [x] `renovate.json` valid JSON
- [x] `actionlint` clean on `pr-quality.yml`
- [ ] CI green on this branch
- [ ] After merge: confirm Renovate doesn't open a new "pin netresearch/.github" PR within the next run
- [ ] After merge: confirm auto-approve fires on the next maintainer PR

## Related

- Phase 4 of container-CI consolidation: netresearch/phpbu-docker#123 (merged)
- Memory pattern: first-party reusables use `@main`, never SHA-pinned (different trust model from third-party actions)