### PR TITLE
fix(renovate): address unresolved review on PR #124

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,15 +54,14 @@
       "pinDigests": true
     },
     {
-      "description": "First-party Netresearch reusable workflows: never digest-pin. Org policy is @main (or @vN once tagged releases exist). Distinct from third-party actions which DO get SHA-pinned per supply-chain convention. Without this rule, Renovate's earlier digest-pinning produced commit 309fca0 (auto-merge.yml@<sha>) which violates that policy.",
+      "description": "First-party Netresearch reusable workflows: never digest-pin. Org policy is @main (or @vN once tagged releases exist). Distinct from third-party actions, which DO get SHA-pinned per supply-chain convention — different trust models.",
       "matchManagers": [
         "github-actions"
       ],
       "matchPackagePatterns": [
         "^netresearch/"
       ],
-      "pinDigests": false,
-      "enabled": false
+      "pinDigests": false
     },
     {
       "description": "Security updates - high priority",


### PR DESCRIPTION
## Why

PR #124 was merged with 2 unresolved gemini-code-assist threads on the netresearch/* packageRule. Both addressed here.

## What changed

| Reviewer point | Fix |
|---|---|
| Description referenced past commit 309fca0 — config should focus on policy, not history | Removed the incident-history sentence; kept the policy statement + trust-model contrast |
| `enabled: false` is over-restrictive and blocks future security alerts on these refs | Dropped to `pinDigests: false` alone — Renovate still surfaces vulnerability alerts and (eventually) `@vN` tag migration, but never produces digest-pin PRs that violated org policy |

## Test plan

- [x] `renovate.json` valid JSON
- [ ] CI green
- [x] Original PR #124 threads replied-to + resolved via GraphQL with a link here

## Related

Part of a session-wide audit triggered by the user: 3 of 11 merged PRs (this one, snipe-it-docker-compose-stack#15, snipe-it-docker-compose-stack#16) had been merged with unresolved bot-reviewer threads. New memory rule \`feedback_never_merge_with_unresolved_threads\` now requires the GraphQL unresolved-threads query before every `gh pr merge`. Equivalent follow-up PR for the snipe-it threads (which included a HIGH-severity token-leak) is netresearch/snipe-it-docker-compose-stack#17.