### PR TITLE
docs: document why abandoned azure-storage-blob is kept

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,10 @@ COPY --from=composer:2@sha256:1c62c57bb5228569034b7b4d1415b17ba6b731619f7de226ea
 COPY --chown=phpbu:phpbu app/full/composer.json ./composer.json
 COPY --chown=phpbu:phpbu app/full/composer.lock ./composer.lock
 
-# Install dependencies with optimization
+# Install dependencies with optimization.
+# NOTE: composer warns that microsoft/azure-storage-blob is abandoned. This is
+# intentional and accepted — phpbu's Azure Blob sync adapter is hardwired to that
+# SDK and Microsoft shipped no replacement. See README "Supported Sync Targets".
 RUN composer install \
     --no-ansi \
     --no-dev \

--- a/README.md
+++ b/README.md
@@ -240,12 +240,22 @@ services:
 |--------|-------------|---------|
 | Amazon S3 / S3-compatible | `aws/aws-sdk-php` | **full** |
 | Google Cloud Storage | `google/cloud-storage` | **full** |
-| Azure Blob Storage | `microsoft/azure-storage-blob` | **full** |
+| Azure Blob Storage | `microsoft/azure-storage-blob` ⚠️ | **full** |
 | SFTP | `phpseclib/phpseclib` | **full** |
 | FTP | `sebastianfeldmann/ftp` | **full** |
 | Dropbox | `kunalvarma05/dropbox-php-sdk` | **full** |
 | Rsync | system binary | **full** |
 | Local/NFS | - | minimal, full |
+
+> ⚠️ **`microsoft/azure-storage-blob` is abandoned upstream.** Microsoft retired the
+> `microsoft/azure-storage-*` libraries with no Composer replacement. We keep the package
+> intentionally because phpbu's Azure Blob sync adapter
+> ([`Backup\Sync\AzureBlob`](https://github.com/sebastianfeldmann/phpbu/blob/master/src/Backup/Sync/AzureBlob.php))
+> is hardwired to its `MicrosoftAzure\Storage\Blob\BlobRestProxy` client — dropping it would
+> remove Azure sync from the full image. The package still works and its only moving security
+> surface (Guzzle) is patched via Dependabot. A migration to the maintained `azure-oss/storage`
+> SDK has to happen in phpbu upstream first; tracked there. If you don't sync to Azure, use the
+> `minimal` image, which doesn't carry this dependency.
 
 ### Additional Tools (full variant only)
 


### PR DESCRIPTION
Follow-up to #152. Documents the `microsoft/azure-storage-blob` abandonment surfaced by Gemini Code Assist there, so it reads as a known/accepted decision rather than recurring as review noise.

## Context

- `microsoft/azure-storage-blob` is a **direct** require in `app/full/composer.json` — nothing transitive pulls it. It's there so phpbu's Azure Blob sync adapter works.
- phpbu's [`Backup\Sync\AzureBlob`](https://github.com/sebastianfeldmann/phpbu/blob/master/src/Backup/Sync/AzureBlob.php) is **hardwired** to `MicrosoftAzure\Storage\Blob\BlobRestProxy::createBlobService()` — there's no abstraction to swap the client.
- Microsoft **abandoned** the whole `microsoft/azure-storage-*` family (`abandoned: true`, no Composer replacement). The maintained community successor is `azure-oss/storage`, but it's a different namespace — **not drop-in**, so the migration has to happen in phpbu upstream first.
- Real risk is low: the package is a thin Guzzle-based REST wrapper, and Guzzle (its only moving security surface) is patched via Dependabot — see #152.

## What this PR does

Documentation only — no dependency or behavior change:

- **README** sync-targets table: flags the Azure row and adds a note explaining why the abandoned package is kept and pointing Azure-free users to the `minimal` image.
- **Dockerfile**: a comment at the full `composer install` site so the abandonment warning in the build log reads as intentional.

## Not done here (by design)

- No `.trivyignore` — Trivy scans CVEs, not abandonment; it never flagged this.
- No `composer audit` suppression — CI doesn't run `composer audit`.
- Removing the adapter / dropping Azure sync is a separate product decision; this PR keeps current behavior.

An upstream phpbu issue proposing the `azure-oss/storage` migration is being drafted; its link will be added here once filed.