### PR TITLE
fix(full): replace abandoned azure-storage-blob with azure-oss/storage

### DIFF
--- a/app/full/composer.json
+++ b/app/full/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=8.5",
-        "phpbu/phpbu": "^6.0",
+        "phpbu/phpbu": "^6.0.32",
         "aws/aws-sdk-php": "^3.10",
         "google/cloud-storage": "^2.0",
-        "microsoft/azure-storage-blob": "^1.4",
+        "azure-oss/storage": "^1.9",
         "phpseclib/phpseclib": "^3.0",
         "sebastianfeldmann/ftp": "^0.9.2",
         "kunalvarma05/dropbox-php-sdk": "^0.5",

--- a/app/full/composer.lock
+++ b/app/full/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e4c941b5dc3af785c2b9a97b92156fb",
+    "content-hash": "ec8eaac12a8e88131cff35119dcad130",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -158,6 +158,155 @@
             "time": "2026-06-19T18:07:45+00:00"
         },
         {
+            "name": "azure-oss/identity",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Azure-OSS/azure-identity-php.git",
+                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Azure-OSS/azure-identity-php/zipball/bff54412a3af6c6f7e68d36cb2d857edc338581a",
+                "reference": "bff54412a3af6c6f7e68d36cb2d857edc338581a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": "^8.1",
+                "php-http/discovery": "^1.20",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.10",
+                "laravel/pint": "^1.27",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^13.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Provides a PSR-18 HTTP client and PSR-17 factories (used by default when installed)."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AzureOss\\Identity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "support": {
+                "issues": "https://github.com/Azure-OSS/azure-identity-php/issues",
+                "source": "https://github.com/Azure-OSS/azure-identity-php/tree/1.0.2"
+            },
+            "time": "2026-03-15T21:17:16+00:00"
+        },
+        {
+            "name": "azure-oss/storage",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Azure-OSS/azure-storage-php.git",
+                "reference": "ed2d4ad652cc90fa8067d9e47468666ed942cf76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Azure-OSS/azure-storage-php/zipball/ed2d4ad652cc90fa8067d9e47468666ed942cf76",
+                "reference": "ed2d4ad652cc90fa8067d9e47468666ed942cf76",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/storage-common": "^1.0",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "aliases.php"
+                ],
+                "psr-4": {
+                    "AzureOss\\Storage\\Blob\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                },
+                {
+                    "name": "Pim Jansen",
+                    "email": "pimjansen@gmail.com"
+                }
+            ],
+            "description": "Azure Blob Storage PHP SDK",
+            "keywords": [
+                "azure",
+                "php",
+                "sdk",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/Azure-OSS/azure-storage-php/tree/1.9.0"
+            },
+            "time": "2026-03-15T06:57:10+00:00"
+        },
+        {
+            "name": "azure-oss/storage-common",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Azure-OSS/azure-storage-php-common.git",
+                "reference": "3169c2f19475a087963e71aeb2cbf183eb676025"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Azure-OSS/azure-storage-php-common/zipball/3169c2f19475a087963e71aeb2cbf183eb676025",
+                "reference": "3169c2f19475a087963e71aeb2cbf183eb676025",
+                "shasum": ""
+            },
+            "require": {
+                "azure-oss/identity": "^1.0",
+                "caseyamcl/guzzle_retry_middleware": "^2.10",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "aliases.php"
+                ],
+                "psr-4": {
+                    "AzureOss\\Storage\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brecht Vermeersch",
+                    "email": "brechtvermeersch@outlook.be"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/Azure-OSS/azure-storage-php-common/tree/1.1.0"
+            },
+            "time": "2026-03-13T19:18:28+00:00"
+        },
+        {
             "name": "brick/math",
             "version": "0.18.0",
             "source": {
@@ -215,6 +364,79 @@
                 }
             ],
             "time": "2026-06-14T18:21:03+00:00"
+        },
+        {
+            "name": "caseyamcl/guzzle_retry_middleware",
+            "version": "v2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/caseyamcl/guzzle_retry_middleware.git",
+                "reference": "17c9299cde438b00bbeb099c6480319a81636a60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/caseyamcl/guzzle_retry_middleware/zipball/17c9299cde438b00bbeb099c6480319a81636a60",
+                "reference": "17c9299cde438b00bbeb099c6480319a81636a60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "jaschilz/php-coverage-badger": "^2.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.0",
+                "phpunit/phpunit": "^7.5|^8.0|^9.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^5.0|^6.0|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleRetry\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Casey McLaughlin",
+                    "email": "caseyamcl@gmail.com",
+                    "homepage": "https://caseymclaughlin.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Guzzle v6+ retry middleware that handles 429/503 status codes and connection timeouts",
+            "homepage": "https://github.com/caseyamcl/guzzle_retry_middleware",
+            "keywords": [
+                "Guzzle",
+                "back-off",
+                "caseyamcl",
+                "guzzle_retry_middleware",
+                "middleware",
+                "retry",
+                "retry-after"
+            ],
+            "support": {
+                "issues": "https://github.com/caseyamcl/guzzle_retry_middleware/issues",
+                "source": "https://github.com/caseyamcl/guzzle_retry_middleware/tree/v2.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/caseyamcl",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-11T12:33:22+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -1404,103 +1626,6 @@
             "time": "2024-08-05T07:37:25+00:00"
         },
         {
-            "name": "microsoft/azure-storage-blob",
-            "version": "1.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Azure/azure-storage-blob-php.git",
-                "reference": "1023ce1dbf062351a32ca5ec72ad1fd4a504f1bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Azure/azure-storage-blob-php/zipball/1023ce1dbf062351a32ca5ec72ad1fd4a504f1bf",
-                "reference": "1023ce1dbf062351a32ca5ec72ad1fd4a504f1bf",
-                "shasum": ""
-            },
-            "require": {
-                "microsoft/azure-storage-common": "~1.5",
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MicrosoftAzure\\Storage\\Blob\\": "src/Blob"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Azure Storage PHP Client Library",
-                    "email": "dmsh@microsoft.com"
-                }
-            ],
-            "description": "This project provides a set of PHP client libraries that make it easy to access Microsoft Azure Storage Blob APIs.",
-            "keywords": [
-                "azure",
-                "blob",
-                "php",
-                "sdk",
-                "storage"
-            ],
-            "support": {
-                "issues": "https://github.com/Azure/azure-storage-blob-php/issues",
-                "source": "https://github.com/Azure/azure-storage-blob-php/tree/v1.5.4"
-            },
-            "abandoned": true,
-            "time": "2022-09-02T02:13:06+00:00"
-        },
-        {
-            "name": "microsoft/azure-storage-common",
-            "version": "1.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Azure/azure-storage-common-php.git",
-                "reference": "8ca7b1bf4c9ca7c663e75a02a0035b05b37196a0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Azure/azure-storage-common-php/zipball/8ca7b1bf4c9ca7c663e75a02a0035b05b37196a0",
-                "reference": "8ca7b1bf4c9ca7c663e75a02a0035b05b37196a0",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "~6.0|^7.0",
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MicrosoftAzure\\Storage\\Common\\": "src/Common"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Azure Storage PHP Client Library",
-                    "email": "dmsh@microsoft.com"
-                }
-            ],
-            "description": "This project provides a set of common code shared by Azure Storage Blob, Table, Queue and File PHP client libraries.",
-            "keywords": [
-                "azure",
-                "common",
-                "php",
-                "sdk",
-                "storage"
-            ],
-            "support": {
-                "issues": "https://github.com/Azure/azure-storage-common-php/issues",
-                "source": "https://github.com/Azure/azure-storage-common-php/tree/v1.5.2"
-            },
-            "time": "2021-10-09T03:03:47+00:00"
-        },
-        {
             "name": "monolog/monolog",
             "version": "3.10.0",
             "source": {
@@ -1789,17 +1914,96 @@
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
-            "name": "phpbu/phpbu",
-            "version": "6.0.31",
+            "name": "php-http/discovery",
+            "version": "1.20.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianfeldmann/phpbu.git",
-                "reference": "c912ca6029e22b66300e7424cb1a55b52fa021e9"
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianfeldmann/phpbu/zipball/c912ca6029e22b66300e7424cb1a55b52fa021e9",
-                "reference": "c912ca6029e22b66300e7424cb1a55b52fa021e9",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
+        },
+        {
+            "name": "phpbu/phpbu",
+            "version": "6.0.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/phpbu.git",
+                "reference": "f51694c08142b81e2b015c579d758ab9021514f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/phpbu/zipball/f51694c08142b81e2b015c579d758ab9021514f1",
+                "reference": "f51694c08142b81e2b015c579d758ab9021514f1",
                 "shasum": ""
             },
             "require": {
@@ -1813,11 +2017,11 @@
             },
             "require-dev": {
                 "aws/aws-sdk-php": "^3.10",
+                "azure-oss/storage": "^1.9",
                 "google/apiclient": "^2.7",
                 "google/cloud-storage": "^1.42",
                 "guzzlehttp/guzzle": "^5.3.4|^6.5.8|^7.5.0",
                 "kunalvarma05/dropbox-php-sdk": "^0.5",
-                "microsoft/azure-storage-blob": "^1.4",
                 "php-opencloud/openstack": "^3.0",
                 "phpmailer/phpmailer": "^6.0",
                 "phpseclib/phpseclib": "^2.0",
@@ -1828,11 +2032,11 @@
             },
             "suggest": {
                 "aws/aws-sdk-php": "Require '^3.10' to sync to Amazon S3",
+                "azure-oss/storage": "Require ^1.9 to sync to Azure Blob Storage",
                 "google/apiclient": "Require ^2.0 to sync to Google Drive",
                 "google/cloud-storage": "Require ^1.42 to sync to Google Cloud Storage",
                 "guzzlehttp/guzzle": "Require ^5.3.3|^6.2.1 to write logs to Telegram",
                 "kunalvarma05/dropbox-php-sdk": "Require '^0.2' to sync to Dropbox",
-                "microsoft/azure-storage-blob": "Require ^1.4 to sync to Azure Blob Storage",
                 "php-opencloud/openstack": "Require ^3.0 to sync to OpenStack",
                 "phpmailer/phpmailer": "Require ^6.0 to receive logs via email",
                 "phpseclib/phpseclib": "Require '^2.0' to use SFTP sync",
@@ -1882,7 +2086,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianfeldmann/phpbu/issues",
-                "source": "https://github.com/sebastianfeldmann/phpbu/tree/6.0.31"
+                "source": "https://github.com/sebastianfeldmann/phpbu/tree/6.0.32"
             },
             "funding": [
                 {
@@ -1890,7 +2094,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-04T22:58:58+00:00"
+            "time": "2026-06-20T16:37:35+00:00"
         },
         {
             "name": "phpmailer/phpmailer",


### PR DESCRIPTION
Removes the abandoned `microsoft/azure-storage-blob` SDK from the **full** image by adopting phpbu 6.0.32's migration to the maintained `azure-oss/storage`.

## Background

`microsoft/azure-storage-blob` is abandoned upstream (Microsoft archived it; Packagist `abandoned: true`, no replacement). It was a direct require in the full image only because phpbu's Azure Blob sync adapter was hardwired to it. That's now fixed at the root: phpbu migrated the adapter to `azure-oss/storage` in [sebastianfeldmann/phpbu#402](https://github.com/sebastianfeldmann/phpbu/pull/402), released in [phpbu 6.0.32](https://github.com/sebastianfeldmann/phpbu/releases/tag/6.0.32).

## What changed (`app/full/composer.json` + lock)

- `phpbu/phpbu` `^6.0` → `^6.0.32` (the release whose Azure adapter uses azure-oss).
- Direct require `microsoft/azure-storage-blob: ^1.4` → `azure-oss/storage: ^1.9` (phpbu lists azure-oss as `suggest`/`require-dev`, so the full image still declares it explicitly to enable the adapter).
- `composer update` removed `microsoft/azure-storage-blob` + `microsoft/azure-storage-common` entirely; pulled `azure-oss/storage` 1.9.0, `azure-oss/storage-common`, `azure-oss/identity`.

## Verification

- `composer validate` clean; **no abandoned packages remain in the lock**; `composer audit` reports no advisories.
- phpbu 6.0.32's `azureblob` sync runs in `--simulate` under PHP 8.5: loads `AzureOss\Storage\Blob\BlobServiceClient` (no "SDK not loaded") and masks the credential (`connectionString: ********`).
- The Security Scan (Trivy) runs on this PR and rebuilds the full image — it should now be clean of the abandonment finding.

## Supersedes

This replaces the documentation-only workaround in #153 (which explained why the abandoned package was kept). With the package removed, that note is obsolete — closing #153 in favour of this fix.