### PR TITLE
fix(ci): drop conflicting delete-untagged from package cleanup

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -31,7 +31,6 @@ jobs:
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           packages: ${{ env.PACKAGE_NAME }}
-          delete-untagged: true          # orphaned untagged manifests
           delete-partial-images: true    # incomplete multi-arch pushes
           delete-ghost-images: true      # tags whose children were GC'd
           keep-n-untagged: 10            # rollback margin


### PR DESCRIPTION
## Problem
The weekly **Cleanup Old Packages** run has failed on `main` for 3 weeks straight. `dataaxiom/ghcr-cleanup-action` rejects `delete-untagged: true` and `keep-n-untagged: 10` being set together:

```
##[error]delete-untagged and keep-n-untagged cannot be set at the same time
```

The action errors on input validation **before touching any package** — so nothing was deleted (no images bricked), but the job fails every schedule.

## Fix
Drop `delete-untagged: true`, keep `keep-n-untagged: 10`. That already prunes untagged versions beyond the 10 newest while preserving the rollback margin, and the action stays manifest-aware (children + cosign/SLSA referrers of tagged images are retained).