### PR TITLE
ci: route release through central bake + gh-release reusables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,103 +6,78 @@ on:
 
 permissions: {}
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  release:
+  # Strip the leading v from the tag once, for the release body. No external
+  # actions (policy: actions live only in shared workflows).
+  version:
+    name: Resolve version
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
-      id-token: write
-      attestations: write
-
+      contents: read
+    outputs:
+      version: ${{ steps.v.outputs.version }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "major=$(echo $VERSION | cut -d. -f1)" >> $GITHUB_OUTPUT
-          echo "minor=$(echo $VERSION | cut -d. -f1-2)" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          echo "git_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Build and push (both variants)
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          targets: minimal,full
-          push: true
-          sbom: true
-          provenance: mode=max
-          set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+      - id: v
         env:
-          PHPBU_VERSION: ${{ steps.version.outputs.version }}
-          PHPBU_MINOR: ${{ steps.version.outputs.minor }}
-          PHPBU_MAJOR: ${{ steps.version.outputs.major }}
-          BUILD_DATE: ${{ steps.version.outputs.build_date }}
-          GIT_SHA: ${{ steps.version.outputs.git_sha }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+  # Build both variants via bake, push, sign every produced tag, emit SBOM +
+  # SLSA provenance. Version facts come from the tag via pre-build-command.
+  build:
+    needs: version
+    uses: netresearch/.github/.github/workflows/build-container-bake.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+    with:
+      targets: minimal,full
+      push: true
+      sign: true
+      sbom: true
+      attest: true
+      scan: false
+      pre-build-command: |
+        V="${GITHUB_REF_NAME#v}"
+        {
+          echo "PHPBU_VERSION=$V"
+          echo "PHPBU_MINOR=$(echo "$V" | cut -d. -f1-2)"
+          echo "PHPBU_MAJOR=$(echo "$V" | cut -d. -f1)"
+          echo "BUILD_DATE=$(date -u +%Y-%m-%d)"
+          echo "GIT_SHA=$(git rev-parse --short HEAD)"
+        } >> "$GITHUB_ENV"
 
-      - name: Sign images
-        run: |
-          # Sign minimal variant tags
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.build_date }}
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          # Sign full variant tags
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-full
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-full-${{ steps.version.outputs.build_date }}
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:full
+  release:
+    needs: [version, build]
+    uses: netresearch/.github/.github/workflows/gh-release-image.yml@main
+    permissions:
+      contents: write
+    with:
+      body: |
+        ## Docker Images
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          generate_release_notes: true
-          body: |
-            ## Docker Images
+        ### Minimal variant (~50MB) - database backups only
+        ```bash
+        docker pull ghcr.io/netresearch/phpbu-docker:${{ needs.version.outputs.version }}
+        ```
 
-            ### Minimal variant (~50MB) - database backups only
-            ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ```
+        ### Full variant (~150MB) - all sync adapters (S3, SFTP, Azure, etc.)
+        ```bash
+        docker pull ghcr.io/netresearch/phpbu-docker:${{ needs.version.outputs.version }}-full
+        ```
 
-            ### Full variant (~150MB) - all sync adapters (S3, SFTP, Azure, etc.)
-            ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-full
-            ```
+        ## Verify Signature
 
-            ## Verify Signature
+        ```bash
+        cosign verify ghcr.io/netresearch/phpbu-docker:${{ needs.version.outputs.version }} \
+          --certificate-identity-regexp "https://github.com/netresearch/phpbu-docker" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+        ```
 
-            ```bash
-            cosign verify ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
-              --certificate-identity-regexp "https://github.com/${{ github.repository }}" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-            ```
+        ## SBOM
 
-            ## SBOM
-
-            ```bash
-            cosign download sbom ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ```
+        ```bash
+        cosign download sbom ghcr.io/netresearch/phpbu-docker:${{ needs.version.outputs.version }}
+        ```


### PR DESCRIPTION
Replaces the inline release job (`docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/bake-action`, `sigstore/cosign-installer` + manual `cosign sign`, `softprops/action-gh-release`) with:
- `build-container-bake.yml@main` — builds `minimal,full`, pushes, **signs every produced tag** (replaces the manual 6-tag cosign loop), emits SBOM + SLSA provenance. Version facts come from the tag via `pre-build-command`.
- `gh-release-image.yml@main` — creates the GitHub Release with the same pull/verify/SBOM notes.

A tiny `version` job strips the `v` prefix for the body (no external action). No external action is referenced directly anymore.

⚠️ Tag-triggered — verifies on the next release tag; validated here via actionlint + structure.