### PR TITLE
ci: validate composer manifests against their lock files

### DIFF
--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Netresearch DTT GmbH
+#
+# Manifest/lock consistency gate.
+#
+# A composer.json raised without regenerating its composer.lock used to surface
+# only once a multi-arch image build reached `composer install`, roughly ninety
+# seconds in, as a bare `exit code: 4` whose actual message sat four lines
+# earlier in the log. It has happened: Renovate bumped a guzzle constraint and
+# left the lock behind, and four CI runs were spent on it.
+#
+# `composer validate --check-lock` answers the same question in about a second
+# and prints the package and the two versions by name, e.g.
+#   Required package "guzzlehttp/guzzle" is in the lock file as "7.15.2" but
+#   that does not satisfy your constraint "^8.0".
+# Where a constraint merely moved without becoming unsatisfiable, only the
+# recorded content hash diverges and composer reports that instead — no package
+# can be named there, because none is in conflict.
+#
+# This is a diagnosis-speed gate, not a replacement for build.yml or test.yml:
+# it proves the manifests and locks agree, never that the image builds.
+
+name: Composer Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  validate:
+    name: manifests vs. lock files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Report toolchain
+        # No setup-php step: the check compares the lock's content hash and its
+        # recorded versions against the manifest's constraints, which is
+        # independent of the platform PHP. Verified on PHP 8.3 and 8.5 with
+        # composer 2.7 and 2.9 against these manifests, which require php>=8.5.
+        # Printed so a change in the runner image is visible in the log.
+        run: |
+          php --version | head -1
+          composer --version
+
+      - name: Validate every manifest against its lock
+        # git ls-files rather than find, so the set is exactly the tracked
+        # manifests — vendor/ and any untracked leftovers on the runner cannot
+        # widen it. Today that is app/ and app/full/; a third variant is picked
+        # up without editing this workflow.
+        run: |
+          set -uo pipefail
+          mapfile -t manifests < <(git ls-files '*composer.json')
+          if [ "${#manifests[@]}" -eq 0 ]; then
+            echo "::error::No tracked composer.json found — this workflow is validating nothing."
+            exit 1
+          fi
+          status=0
+          for manifest in "${manifests[@]}"; do
+            dir=$(dirname "$manifest")
+            echo "::group::$manifest"
+            if [ ! -f "$dir/composer.lock" ]; then
+              echo "::error file=$manifest::No composer.lock beside this manifest. Every composer.json here is installed from a lock during the image build, so an unlocked one fails the build instead of this check."
+              status=1
+            elif ! (cd "$dir" && composer validate --check-lock --no-check-publish --strict --no-interaction); then
+              echo "::error file=$dir/composer.lock::Out of date with $manifest. Re-resolve in $dir/: 'composer update <package>' for a package named above, or 'composer update --lock' when only the content hash drifted. '--lock' alone refreshes the hash and leaves a named mismatch in place."
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ flowchart LR
 
 - [ ] Dockerfile passes hadolint
 - [ ] `docker buildx bake --print` validates bake file
+- [ ] Every `composer.json` still agrees with its `composer.lock`
 - [ ] Image builds successfully
 - [ ] `--version` and `--help` work
 - [ ] No new critical/high vulnerabilities (Trivy)
@@ -121,6 +122,32 @@ docker run --rm phpbu:ci --help
 docker run --rm phpbu:ci-full --version
 docker run --rm phpbu:ci-full which rsync gpg ssh
 ```
+
+### Composer Manifests
+
+Both `app/` and `app/full/` are installed from their lock files during the image
+build, so a constraint changed without regenerating the lock breaks the build
+about ninety seconds in, as a bare `exit code: 4`. The same question takes a
+second up front:
+
+```bash
+# Per manifest — repeat in app/ and app/full/
+composer validate --check-lock --no-check-publish --strict
+```
+
+Two things can be wrong, and they need different fixes:
+
+- **A named package** — `Required package "x/y" is in the lock file as "1.2.3"
+  but that does not satisfy your constraint "^2.0"`. Re-resolve it:
+  `composer update x/y`.
+- **Only the content hash** — `The lock file is not up to date with the latest
+  changes in composer.json`, with no package named. The lock still satisfies
+  every constraint; refresh the hash with `composer update --lock`.
+
+`composer update --lock` does *not* fix the first case: it rewrites the hash and
+leaves the version mismatch behind, so `validate` still fails.
+
+CI runs this over every tracked `composer.json` in `composer-validate.yml`.
 
 ### Security Scanning
 


### PR DESCRIPTION
There is no `composer validate --check-lock` anywhere in `.github/`, so a manifest and its lock disagreeing surfaces only once the multi-arch build reaches `composer install` — roughly ninety seconds in, as a bare `exit code: 4` whose real message sits four lines earlier in the log. That has already happened: Renovate raised a guzzle constraint without regenerating the lock, and four CI runs went on it.

This adds `.github/workflows/composer-validate.yml`, running `composer validate --check-lock --no-check-publish --strict` over every tracked `composer.json`. There are two, not one — `app/composer.json` and `app/full/composer.json` — and both are discovered via `git ls-files '*composer.json'` rather than named, so a third variant is covered without editing the workflow, and `vendor/` or untracked leftovers on the runner cannot widen the set. It runs on pull requests and on pushes to `main`, matching `test.yml`.

No `setup-php` step. The check compares the lock's content hash and its recorded versions against the manifest's constraints, which does not depend on the platform PHP — verified on PHP 8.3 with composer 2.7 and on PHP 8.5 with composer 2.9, against manifests that require `php >=8.5`; both report `./composer.json is valid`. That avoids adding a third-party action and a SHA to keep current, and the job prints `php --version` and `composer --version` so a change in the runner image is visible in the log.

This is a diagnosis-speed gate, not a replacement for `build.yml` or `test.yml`: it proves the manifests and locks agree, never that the image builds.

## Verification

Against the current tree, which is self-consistent — `app/full/composer.json` says `^7.5` and the lock has 7.15.2:

```
::group::app/composer.json
./composer.json is valid
::endgroup::
::group::app/full/composer.json
./composer.json is valid
::endgroup::
STEP EXIT=0
```

0.54s for both manifests, and it completes with `--network none`.

Against a copy of the same tree in a scratch directory with `guzzlehttp/guzzle` raised to `^8.0` and the lock left alone — the exact shape of the incident:

```
::group::app/composer.json
./composer.json is valid
::endgroup::
::group::app/full/composer.json
./composer.json is valid but your composer.lock has some errors
# Lock file errors
- The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update` or `composer update <package name>`.
- Required package "guzzlehttp/guzzle" is in the lock file as "7.15.2" but that does not satisfy your constraint "^8.0".
::error file=app/full/composer.lock::Out of date with app/full/composer.json. Re-resolve in app/full/: 'composer update <package>' for a package named above, or 'composer update --lock' when only the content hash drifted. '--lock' alone refreshes the hash and leaves a named mismatch in place.
::endgroup::
STEP EXIT=1
```

Composer names the package and both versions itself. For reference, `composer install --dry-run` on that same tree exits 4 — the code the build was reporting.

The missing-lock branch was exercised too: deleting `app/composer.lock` fails that manifest with the explicit annotation while `app/full/` still validates, so one bad manifest does not mask the others.

`actionlint` exits 0 on the new file and on all ten workflows together.

## One correction worth flagging

The first version of the error annotation told you to run `composer update --lock`. That is wrong for the case where a package is named: `--lock` refreshes the content hash and leaves the version mismatch in place, so `validate` still fails afterwards — measured, guzzle stayed at 7.15.2 against `^8.0`. It is the right fix only when the hash alone drifted, which was also measured. The annotation and the CONTRIBUTING section now distinguish the two.

## Out of scope, noticed while reading

`README.md` carries a `Security Scan` badge pointing at `.github/workflows/security.yml`, which no longer exists — `ci.yml` records it as subsumed. The badge renders as a permanent failure. Left alone here.
